### PR TITLE
Remove unused core.async dependency

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -3,7 +3,6 @@
  :resource-paths #{"resources"}
 
  :dependencies '[[org.clojure/clojure "1.9.0-alpha10"]
-                 [org.clojure/core.async "0.2.385"]
                  [org.clojure/clojurescript "1.9.89"]
                  [org.clojure/tools.namespace "0.2.11" :scope "test"]
                  [org.clojure/tools.nrepl "0.2.12" :scope "test"]    ;; needed by bREPL

--- a/test/cljs/cache_test.cljs
+++ b/test/cljs/cache_test.cljs
@@ -7,12 +7,10 @@
 ;   You must not remove this notice, or any other, from this software.
 
 (ns cljs.cache-test
-  (:require [cljs.core.async :refer [chan close! <!]]
-            [cljs.test :refer-macros [deftest run-tests testing is are async]]
-            [cljs.cache :refer [BasicCache TTLCache LRUCache
+  (:require [cljs.cache :refer [BasicCache TTLCache LRUCache
                                 ttl-cache-factory lru-cache-factory
-                                lookup has? hit miss evict seed]])
-  (:require-macros [cljs.core.async.macros :refer [go]]))
+                                lookup has? hit miss evict seed]]
+            [cljs.test :refer-macros [deftest run-tests testing is are async]]))
 
 (enable-console-print!)
 


### PR DESCRIPTION
Seems to have not been used, but some functions and macros were required in the test namespace. I removed them all here.